### PR TITLE
Fix LSP kind display

### DIFF
--- a/rplugin/python3/deoplete/source/lsp.py
+++ b/rplugin/python3/deoplete/source/lsp.py
@@ -132,9 +132,6 @@ class Source(Base):
                   'value' in rec['documentation']):
                 item['info'] = rec['documentation']['value']
 
-            if rec.get('insertTextFormat') == 2:
-                item['kind'] = 'Snippet'
-
             candidates.append(item)
 
         return candidates


### PR DESCRIPTION
The type of complement candidate is not Snippet, but it is Method.

<img width="761" alt="スクリーンショット 2020-08-23 2 44 38" src="https://user-images.githubusercontent.com/3197942/90962456-18a2ee80-e4eb-11ea-8fc0-29a59140d61b.png">


Changed the display to be suitable for the type of complement candidate.

<img width="755" alt="スクリーンショット 2020-08-23 2 43 54" src="https://user-images.githubusercontent.com/3197942/90962449-0d4fc300-e4eb-11ea-86f8-8a372df832ed.png">

